### PR TITLE
Serial Type 1: correction

### DIFF
--- a/NotionalSQLite.py
+++ b/NotionalSQLite.py
@@ -124,7 +124,7 @@ class NotionalSQLite:
                 celldatalist.append(recordnum)
             elif field[0] == "ST_INT8":
                 self.dbfile.seek(dataoffset)
-                celldatalist.append(ord(struct.unpack(">c",self.dbfile.read(1))[0]))
+                celldatalist.append(struct.unpack("b",self.dbfile.read(1))[0])
                 dataoffset+=field[1]
             elif field[0] == "ST_INT16":
                 self.dbfile.seek(dataoffset)


### PR DESCRIPTION
Corrected Serial Type 1 (8-bit two's complement integer) from 'ord(char)' to signed char to reflect two's complement